### PR TITLE
Add support by excluding specific fields from index

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,19 @@ branches:
   only:
   - master
 
+matrix:
+  fast_finish: false
+  include:
+    - env: ENV=unit-tests
+      script:
+        - cd datastore-translator
+        - go test -v ./... -race -coverprofile=coverage.txt -covermode=atomic
+    - env: ENV=unit-tests
+      script:
+        - cd datastore-translator
+        - go test -v ./... -race -tags=integration
+
+
 notifications:
   email:
     on_success: change
@@ -25,14 +38,8 @@ before_script:
   - curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
   - sudo apt-get update && sudo apt-get install google-cloud-sdk
   - nohup gcloud beta emulators datastore start --host-port=127.0.0.1:8081 --no-store-on-disk &
-  - sleep 30
-  - export DATASTORE_EMULATOR_HOST=localhost:8081
-
-script:
-  - cd datastore-translator
-  - echo $DATASTORE_EMULATOR_HOST
-  - go test -v ./... -race -coverprofile=coverage.txt -covermode=atomic
-  - go test -v ./... -race -tags=integration
+  - sleep 10
+  - $(gcloud beta emulators datastore env-init)
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,12 +36,7 @@ notifications:
 install: true
 
 before_script:
-  - export CLOUD_SDK_REPO="cloud-sdk-$(lsb_release -c -s)"
-  - echo "deb http://packages.cloud.google.com/apt $CLOUD_SDK_REPO main" | sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
-  - curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
-  - sudo apt-get update && sudo apt-get install google-cloud-sdk
-  - nohup gcloud beta emulators datastore start --host-port=127.0.0.1:8081 --no-store-on-disk &
-  - sleep 10
+  - ./scripts/run-datastore-emulator.sh
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ before_script:
   - echo "deb http://packages.cloud.google.com/apt $CLOUD_SDK_REPO main" | sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
   - curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
   - sudo apt-get update && sudo apt-get install google-cloud-sdk
-  - nohup gcloud beta emulators datastore start &
+  - nohup gcloud beta emulators datastore start --host-port=127.0.0.1:8081 --no-store-on-disk &
   - sleep 30
   - export DATASTORE_EMULATOR_HOST=localhost:8081
 
@@ -32,7 +32,7 @@ script:
   - cd datastore-translator
   - echo $DATASTORE_EMULATOR_HOST
   - go test -v ./... -race -coverprofile=coverage.txt -covermode=atomic
-#  - go test -v ./... -race -tags=integration
+  - go test -v ./... -race -tags=integration
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,11 +19,14 @@ matrix:
       script:
         - cd datastore-translator
         - go test -v ./... -race -coverprofile=coverage.txt -covermode=atomic
-    - env: ENV=unit-tests
+    - env: ENV=integration-tests
       script:
         - cd datastore-translator
+        - export DATASTORE_EMULATOR_HOST=127.0.0.1:8081
+        - export DATASTORE_EMULATOR_HOST_PATH=127.0.0.1:8081/datastore
+        - export DATASTORE_HOST=http://127.0.0.1:8081
+        - export DATASTORE_PROJECT_ID=translator-tests
         - go test -v ./... -race -tags=integration
-
 
 notifications:
   email:
@@ -39,7 +42,6 @@ before_script:
   - sudo apt-get update && sudo apt-get install google-cloud-sdk
   - nohup gcloud beta emulators datastore start --host-port=127.0.0.1:8081 --no-store-on-disk &
   - sleep 10
-  - $(gcloud beta emulators datastore env-init)
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,17 +15,18 @@ branches:
 matrix:
   fast_finish: false
   include:
-    - env: ENV=unit-tests
+    - name: Unit Tests
       script:
         - cd datastore-translator
         - go test -v ./... -race -coverprofile=coverage.txt -covermode=atomic
-    - env: ENV=integration-tests
+    - name: Integration Tests
+      env:
+        - DATASTORE_EMULATOR_HOST=127.0.0.1:8081
+        - DATASTORE_EMULATOR_HOST_PATH=127.0.0.1:8081/datastore
+        - DATASTORE_HOST=http://127.0.0.1:8081
+        - DATASTORE_PROJECT_ID=translator-tests
       script:
         - cd datastore-translator
-        - export DATASTORE_EMULATOR_HOST=127.0.0.1:8081
-        - export DATASTORE_EMULATOR_HOST_PATH=127.0.0.1:8081/datastore
-        - export DATASTORE_HOST=http://127.0.0.1:8081
-        - export DATASTORE_PROJECT_ID=translator-tests
         - go test -v ./... -race -tags=integration
 
 notifications:

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 This is largely inspired from being able to persist protocol buffers to Google Cloud Datastore. Protobuf messages that the datstore supports are listed [here](https://github.com/googleapis/googleapis/blob/c50d9e822e19e069b7e3758736ea58cb4f35267c/google/datastore/v1/entity.proto#L188).
  
-This repository acts as a translator to translate any given ``proto.Message`` to ``datastore.Entity`` that the datastore understands and 
+This repository acts as atranslator to translate any given ``proto.Message`` to ``datastore.Entity`` that the datastore understands and 
 ``datastore.Entity`` to any ``proto.Message``.
 
 This repository also addresses some of the limitations that [google-cloud-go](https://github.com/googleapis/google-cloud-go/tree/master/datastore) has.
@@ -62,7 +62,7 @@ func main() {
 	}
 
 	// 3. translate the protobuf message to the format that datastore understands
-	entity, err := translator.ProtoMessageToDatastoreEntity(execReq, true)
+	entity, err := translator.ProtoMessageToDatastoreEntity(execReq, true, nil)
 	if err != nil {
 		log.Fatalf("unable to translate execution request to datastore format, error: %v", err)
 	}
@@ -88,7 +88,7 @@ func main() {
 	dsExecReq := &execution.ExecutionRequest{}
 
 	// 8. convert the value fetched from datastore to protobuf
-	err = translator.DatastoreEntityToProtoMessage(dsEntity,dsExecReq, true)
+	err = translator.DatastoreEntityToProtoMessage(dsEntity,dsExecReq, true, nil)
 	if err != nil {
 		log.Fatalf("error while converting to proto message, %v", err)
 	}

--- a/datastore-translator/translator_integration_test.go
+++ b/datastore-translator/translator_integration_test.go
@@ -11,13 +11,18 @@ import (
 	"gotest.tools/assert"
 	"log"
 	"testing"
+	"time"
 )
 
 func TestIntegration(t *testing.T) {
 	ctx := context.Background()
+
 	// 1. create a new datastore client
 	client, err := datastore.NewClient(ctx, "st2-saas-prototype-dev")
 	assert.NilError(t, err)
+
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
 
 	// 2. create a key that we plan to save into
 	key := datastore.NameKey("Example_DB_Model", "complex_proto_2", nil)
@@ -120,6 +125,9 @@ func TestEmptyProtoMessage(t *testing.T) {
 	client, err := datastore.NewClient(ctx, "st2-saas-prototype-dev")
 	assert.NilError(t, err)
 
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
 	// 2. create a key that we plan to save into
 	key := datastore.NameKey("Example_DB_Model", "complex_proto_empty", nil)
 
@@ -148,6 +156,9 @@ func TestProtoWithNilPointer(t *testing.T) {
 	// 1. create a new datastore client
 	client, err := datastore.NewClient(ctx, "st2-saas-prototype-dev")
 	assert.NilError(t, err)
+
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
 
 	// 2. create a key that we plan to save into
 	key := datastore.NameKey("Example_DB_Model", "complex_proto_empty", nil)

--- a/datastore-translator/translator_integration_test.go
+++ b/datastore-translator/translator_integration_test.go
@@ -60,7 +60,7 @@ func TestIntegration(t *testing.T) {
 
 	log.Printf("original proto: %v", srcProto)
 	// 4. translate the source protobuf to datastore.Entity
-	translatedSrcProto, err := ProtoMessageToDatastoreEntity(srcProto, true)
+	translatedSrcProto, err := ProtoMessageToDatastoreEntity(srcProto, true, nil)
 	assert.NilError(t, err)
 
 	// 5. save the translated protobuf to datastore
@@ -124,7 +124,7 @@ func TestEmptyProtoMessage(t *testing.T) {
 	key := datastore.NameKey("Example_DB_Model", "complex_proto_empty", nil)
 
 	srcProto := &example.ExampleDBModel{}
-	translatedProto, err := ProtoMessageToDatastoreEntity(srcProto, false)
+	translatedProto, err := ProtoMessageToDatastoreEntity(srcProto, false, nil)
 	assert.NilError(t, err)
 
 	_, err = client.PutEntity(ctx, key, &translatedProto)
@@ -155,7 +155,7 @@ func TestProtoWithNilPointer(t *testing.T) {
 	srcProto := &example.ExampleDBModel{
 		TimestampKey: ptypes.TimestampNow(),
 	}
-	translatedProto, err := ProtoMessageToDatastoreEntity(srcProto, false)
+	translatedProto, err := ProtoMessageToDatastoreEntity(srcProto, false, nil)
 	assert.NilError(t, err)
 
 	_, err = client.PutEntity(ctx, key, &translatedProto)

--- a/datastore-translator/translator_integration_test.go
+++ b/datastore-translator/translator_integration_test.go
@@ -14,6 +14,8 @@ import (
 	"time"
 )
 
+const DATASTORE_CONNECT_TIMEOUT = 5 * time.Second
+
 func TestIntegration(t *testing.T) {
 	ctx := context.Background()
 
@@ -21,7 +23,7 @@ func TestIntegration(t *testing.T) {
 	client, err := datastore.NewClient(ctx, "st2-saas-prototype-dev")
 	assert.NilError(t, err)
 
-	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, DATASTORE_CONNECT_TIMEOUT)
 	defer cancel()
 
 	// 2. create a key that we plan to save into
@@ -125,7 +127,7 @@ func TestEmptyProtoMessage(t *testing.T) {
 	client, err := datastore.NewClient(ctx, "st2-saas-prototype-dev")
 	assert.NilError(t, err)
 
-	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, DATASTORE_CONNECT_TIMEOUT)
 	defer cancel()
 
 	// 2. create a key that we plan to save into
@@ -157,7 +159,7 @@ func TestProtoWithNilPointer(t *testing.T) {
 	client, err := datastore.NewClient(ctx, "st2-saas-prototype-dev")
 	assert.NilError(t, err)
 
-	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, DATASTORE_CONNECT_TIMEOUT)
 	defer cancel()
 
 	// 2. create a key that we plan to save into

--- a/datastore-translator/ts_struct_test.go
+++ b/datastore-translator/ts_struct_test.go
@@ -15,7 +15,7 @@ func TestAddTSSupport(t *testing.T) {
 		StartedOn: ptypes.TimestampNow(),
 	}
 	log.Println("Source: ", src)
-	srcEntity, err := ProtoMessageToDatastoreEntity(src, false)
+	srcEntity, err := ProtoMessageToDatastoreEntity(src, false, nil)
 
 	assert.NilError(t, err)
 	log.Println("Source Datastore Entity: ", srcEntity)
@@ -50,7 +50,7 @@ func TestAddStructSupport(t *testing.T) {
 		},
 	}
 	log.Println("Source: ", src)
-	srcEntity, err := ProtoMessageToDatastoreEntity(src, false)
+	srcEntity, err := ProtoMessageToDatastoreEntity(src, false, nil)
 
 	assert.NilError(t, err)
 	log.Println("Source Datastore Entity: ", srcEntity)
@@ -75,7 +75,7 @@ func TestSliceofNestedMessages(t *testing.T) {
 		},
 	}
 	log.Println("Source: ", src)
-	srcEntity, err := ProtoMessageToDatastoreEntity(src, false)
+	srcEntity, err := ProtoMessageToDatastoreEntity(src, false, nil)
 	assert.NilError(t, err)
 
 	log.Println("Source Datastore Entity: ", srcEntity)
@@ -97,7 +97,7 @@ func TestNestedMessages(t *testing.T) {
 		},
 	}
 	log.Println("Source: ", src)
-	srcEntity, err := ProtoMessageToDatastoreEntity(src, false)
+	srcEntity, err := ProtoMessageToDatastoreEntity(src, false, nil)
 	assert.NilError(t, err)
 
 	log.Println("Source Datastore Entity: ", srcEntity)

--- a/scripts/run-datastore-emulator.sh
+++ b/scripts/run-datastore-emulator.sh
@@ -11,7 +11,7 @@ gcloud beta emulators datastore start --host-port=127.0.0.1:8081 --no-store-on-d
 EMULATOR_PID=$!
 
 # Give process some time to start up
-sleep 25
+sleep 5
 
 if ps -p ${EMULATOR_PID} > /dev/null; then
     echo "google cloud datastore emulator successfully started"


### PR DESCRIPTION
This pull request adds support for excluding specific model / entity fields from index by passing ``excludeFromIndex`` argument to the ``ProtoMessageToDatastoreEntity`` method.

This argument should contain a list of original field names which should not be indexed (all the fields are indexed by default).

This is the same change as in https://github.com/Kami/python-protobuf-cloud-datastore-entity-translator/pull/15, but for Go library.